### PR TITLE
DUPLO-8574 Integrate publishing of duplo-jit to brew tap

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,7 +69,6 @@ announce:
     channel: '#duplo-devs'
 release:
   draft: false
-# .goreleaser.yaml
 brews:
   - name: duplo-jit
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,7 +71,7 @@ release:
   draft: false
 brews:
   - name: duplo-jit
-    goarm: 8
+    goarm: 6
     goamd64: v1
     tap:
       owner: duplocloud

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,3 +69,87 @@ announce:
     channel: '#duplo-devs'
 release:
   draft: false
+# .goreleaser.yaml
+brews:
+  - name: duplo-jit
+
+    # IDs of the archives to use.
+    # Empty means all IDs.
+    # ids:
+    # - foo
+    # - bar
+
+    # GOARM to specify which 32-bit arm version to use if there are multiple
+    # versions from the build section. Brew formulas support only one 32-bit
+    # version.
+    #
+    # Default: 6
+    goarm: 6
+
+    # GOAMD64 to specify which amd64 version to use if there are multiple
+    # versions from the build section.
+    #
+    # Default: v1
+    goamd64: v1
+
+    # NOTE: make sure the url_template, the token and given repo (github or
+    # gitlab) owner and name are from the same kind.
+    # We will probably unify this in the next major version like it is
+    # done with scoop.
+
+    # GitHub/GitLab repository to push the formula to
+    tap:
+      # Repository owner.
+      #
+      # Templates: allowed
+      owner: duplocloud
+
+      # Repository name.
+      #
+      # Templates: allowed
+      name: homebrew-tap
+
+      # Optionally a branch can be provided.
+      #
+      # Default: default repository branch.
+      #
+      # Templates: allowed
+      branch: main
+
+      # Optionally a token can be provided, if it differs from the token
+      # provided to GoReleaser
+      token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+
+    # URL which is determined by the given Token (github, gitlab or gitea).
+    #
+    # Default depends on the client.
+    # Templates: allowed
+    url_template: "https://github.com/duplocloud/duplo-jit/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
+
+    # Git author used to commit to the repository.
+    commit_author:
+      name: duplo-bot
+      email: joe+github-bot@duplocloud.net
+
+    # The project name and current git tag are used in the format string.
+    #
+    # Templates: allowed
+    commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
+
+    # Folder inside the repository to put the formula.
+    folder: Formula
+
+    # Your app's homepage.
+    homepage: "https://github.com/duplocloud/duplo-jit"
+
+    # Your app's description.
+    #
+    # Templates: allowed
+    description: "Command-line tools for JIT Duplo, AWS and Kubernetes access"
+
+    # SPDX identifier of your app's license.
+    license: "MIT"
+
+    # So you can `brew test` your formula.
+    test: |
+      system "duplo-jit version"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,84 +71,21 @@ release:
   draft: false
 brews:
   - name: duplo-jit
-
-    # IDs of the archives to use.
-    # Empty means all IDs.
-    # ids:
-    # - foo
-    # - bar
-
-    # GOARM to specify which 32-bit arm version to use if there are multiple
-    # versions from the build section. Brew formulas support only one 32-bit
-    # version.
-    #
-    # Default: 6
     goarm: 6
-
-    # GOAMD64 to specify which amd64 version to use if there are multiple
-    # versions from the build section.
-    #
-    # Default: v1
     goamd64: v1
-
-    # NOTE: make sure the url_template, the token and given repo (github or
-    # gitlab) owner and name are from the same kind.
-    # We will probably unify this in the next major version like it is
-    # done with scoop.
-
-    # GitHub/GitLab repository to push the formula to
     tap:
-      # Repository owner.
-      #
-      # Templates: allowed
       owner: duplocloud
-
-      # Repository name.
-      #
-      # Templates: allowed
       name: homebrew-tap
-
-      # Optionally a branch can be provided.
-      #
-      # Default: default repository branch.
-      #
-      # Templates: allowed
       branch: main
-
-      # Optionally a token can be provided, if it differs from the token
-      # provided to GoReleaser
       token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
-
-    # URL which is determined by the given Token (github, gitlab or gitea).
-    #
-    # Default depends on the client.
-    # Templates: allowed
     url_template: "https://github.com/duplocloud/duplo-jit/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
-
-    # Git author used to commit to the repository.
     commit_author:
       name: duplo-bot
       email: joe+github-bot@duplocloud.net
-
-    # The project name and current git tag are used in the format string.
-    #
-    # Templates: allowed
     commit_msg_template: "Brew formula update for {{ .ProjectName }} version {{ .Tag }}"
-
-    # Folder inside the repository to put the formula.
     folder: Formula
-
-    # Your app's homepage.
     homepage: "https://github.com/duplocloud/duplo-jit"
-
-    # Your app's description.
-    #
-    # Templates: allowed
     description: "Command-line tools for JIT Duplo, AWS and Kubernetes access"
-
-    # SPDX identifier of your app's license.
     license: "MIT"
-
-    # So you can `brew test` your formula.
     test: |
       system "duplo-jit version"

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -71,7 +71,7 @@ release:
   draft: false
 brews:
   - name: duplo-jit
-    goarm: 6
+    goarm: 8
     goamd64: v1
     tap:
       owner: duplocloud


### PR DESCRIPTION
## Change description

> Update duplo-jit release flow to publish to duplocloud/tap homebrew tap

## Type of change
- [ ] Bug fix (fixes an issue)
- [x] New feature (adds functionality)

## Related issues

> DUPLO-8574 

## Checklists

### Development

- [x] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [na] Lint rules pass locally
- [na] Application changes have been tested thoroughly
- [na] Automated tests covering modified code pass

### Security

- [na] Security impact of change has been considered
- [na] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [x] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [x] Pull request linked to task tracker where applicable
