### PR TITLE
Use cross-repo github token as env var to support goreleaser syntax

### DIFF
--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -30,3 +30,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          TAP_GITHUB_TOKEN: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -77,7 +77,7 @@ brews:
       owner: duplocloud
       name: homebrew-tap
       branch: main
-      token: ${{ secrets.RELEASE_BOT_GITHUB_TOKEN }}
+      token: "{{ .Env.TAP_GITHUB_TOKEN }}"
     url_template: "https://github.com/duplocloud/duplo-jit/releases/download/{{ .Tag }}/{{ .ArtifactName }}"
     commit_author:
       name: duplo-bot


### PR DESCRIPTION
This fixes the run error seen trying to publish 0.5.3 to the homebrew tap.

Referencing goreleaser expected env var and secrets syntax here:
https://goreleaser.com/errors/resource-not-accessible-by-integration/?h=secrets#2-use-a-personal-access-token-pat-specifically-for-the-integration