### PR TITLE
DUPLO-13529 Detect token invalidation from user logout

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -63,6 +63,19 @@
             ],
         },
         {
+            "name": "Duplo",
+            "type": "go",
+            "request": "launch",
+            "mode": "auto",
+            "program": "${workspaceFolder}/cmd/duplo-jit/main.go",
+            "args": [
+                "duplo",
+                "--host",
+                "https://test20.duplocloud.net",
+                "--interactive"
+            ],
+        },
+        {
             "name": "K8s Plan",
             "type": "go",
             "request": "launch",

--- a/cmd/duplo-aws-credential-process/main.go
+++ b/cmd/duplo-aws-credential-process/main.go
@@ -93,7 +93,7 @@ func main() {
 		// Otherwise, get the credentials from Duplo.
 		if creds == nil {
 			client := mustDuploClient(*host, *token, *interactive, true)
-			result, err := client.AdminGetJITAwsCredentials()
+			result, err := client.AdminGetJitAwsCredentials()
 			internal.DieIf(err, "failed to get credentials")
 			creds = internal.ConvertAwsCreds(result)
 		}
@@ -143,7 +143,7 @@ func main() {
 			}
 
 			// Tenant: Get the JIT AWS credentials
-			result, err := client.TenantGetJITAwsCredentials(*tenantID)
+			result, err := client.TenantGetJitAwsCredentials(*tenantID)
 			internal.DieIf(err, "failed to get credentials")
 			creds = internal.ConvertAwsCreds(result)
 		}

--- a/cmd/duplo-jit/main.go
+++ b/cmd/duplo-jit/main.go
@@ -106,7 +106,7 @@ func main() {
 			// Otherwise, get the credentials from Duplo.
 			if creds == nil {
 				client, _ := internal.MustDuploClient(*host, *token, *interactive, true)
-				result, err := client.AdminGetJITAwsCredentials()
+				result, err := client.AdminGetJitAwsCredentials()
 				internal.DieIf(err, "failed to get credentials")
 				creds = internal.ConvertAwsCreds(result)
 			}
@@ -148,7 +148,7 @@ func main() {
 			// Otherwise, get the credentials from Duplo.
 			if creds == nil {
 				// Tenant: Get the JIT AWS credentials
-				result, err := client.TenantGetJITAwsCredentials(*tenantID)
+				result, err := client.TenantGetJitAwsCredentials(*tenantID)
 				internal.DieIf(err, "failed to get credentials")
 				creds = internal.ConvertAwsCreds(result)
 			}

--- a/duplocloud/api.go
+++ b/duplocloud/api.go
@@ -30,6 +30,16 @@ type DuploSystemFeatures struct {
 	TenantNameMaxLength   int    `json:"TenantNameMaxLength"`
 }
 
+// DuploInfrastructureConfig represents an infrastructure configuration
+type DuploInfrastructure struct {
+	Name                    string `json:"Name,omitempty"`
+	Region                  string `json:"Region,omitempty"`
+	EnableK8Cluster         bool   `json:"EnableK8Cluster,omitempty"`
+	EnableECSCluster        bool   `json:"EnableECSCluster,omitempty"`
+	EnableContainerInsights bool   `json:"EnableContainerInsights,omitempty"`
+	ProvisioningStatus      string `json:"ProvisioningStatus,omitempty"`
+}
+
 // DuploPlanK8ClusterConfig represents a k8s system configuration
 type DuploPlanK8ClusterConfig struct {
 	Name                           string     `json:"Name,omitempty"`
@@ -94,15 +104,15 @@ func (c *Client) AdminGetK8sJitAccess(plan string) (*DuploPlanK8ClusterConfig, C
 }
 
 // AdminGetJITAwsCredentials retrieves just-in-time admin AWS credentials via the Duplo API.
-func (c *Client) AdminGetJITAwsCredentials() (*AwsJitCredentials, ClientError) {
+func (c *Client) AdminGetJitAwsCredentials() (*AwsJitCredentials, ClientError) {
 	return c.AdminAwsGetJitAccess("admin")
 }
 
 // TenantGetJITAwsCredentials retrieves just-in-time AWS credentials for a tenant via the Duplo API.
-func (c *Client) TenantGetJITAwsCredentials(tenantID string) (*AwsJitCredentials, ClientError) {
+func (c *Client) TenantGetJitAwsCredentials(tenantID string) (*AwsJitCredentials, ClientError) {
 	creds := AwsJitCredentials{}
 	err := c.getAPI(
-		fmt.Sprintf("TenantGetAwsCredentials(%s)", tenantID),
+		fmt.Sprintf("TenantGetJitAwsCredentials(%s)", tenantID),
 		fmt.Sprintf("subscriptions/%s/GetAwsConsoleTokenUrl", tenantID),
 		&creds,
 	)
@@ -134,6 +144,19 @@ func (c *Client) ListTenantsForUser() (*[]UserTenant, ClientError) {
 		return nil, err
 	}
 	return &list, nil
+}
+
+func (c *Client) AdminGetInfrastructure(infraName string) (*DuploInfrastructure, ClientError) {
+	config := DuploInfrastructure{}
+	err := c.getAPI(
+		fmt.Sprintf("AdminGetInfrastructure(%s)", infraName),
+		fmt.Sprintf("v3/admin/infrastructure/%s", infraName),
+		&config,
+	)
+	if err != nil {
+		return nil, err
+	}
+	return &config, nil
 }
 
 // GetTenantByNameForUser retrieves a single tenant by name for the current user via the Duplo API.

--- a/internal/cache.go
+++ b/internal/cache.go
@@ -142,7 +142,7 @@ func CacheGetDuploOutput(cacheKey string, host string) (creds *DuploCredsOutput)
 
 		// Check credentials for expiry - by trying to retrieve system features
 		if creds != nil {
-			// Retrieve system features. This also validates the creds.
+			// Retrieve system features.
 			client, err := duplocloud.NewClient(host, creds.DuploToken)
 			if err == nil {
 				var features *duplocloud.DuploSystemFeatures
@@ -154,6 +154,13 @@ func CacheGetDuploOutput(cacheKey string, host string) (creds *DuploCredsOutput)
 
 			// If we have any errors, assume that the credentials have expired
 			if err != nil {
+				creds = nil
+			}
+		}
+
+		// Validate creds by executing ping
+		if creds != nil {
+			if err := PingDuploCreds(creds, host); err != nil {
 				creds = nil
 			}
 		}

--- a/internal/duplo.go
+++ b/internal/duplo.go
@@ -128,3 +128,17 @@ func OutputDuploCreds(creds *DuploCredsOutput) {
 	os.Stdout.Write(json)
 	os.Stdout.WriteString("\n")
 }
+
+func PingDuploCreds(creds *DuploCredsOutput, host string) error {
+	client, err := duplocloud.NewClient(host, creds.DuploToken)
+	if err != nil {
+		return err
+	}
+
+	_, cerr := client.AdminGetInfrastructure("default")
+	if cerr != nil && cerr.Status() != 404 {
+		return cerr
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Change description

Fixes an issue in which the logic continued to attempt to use a Duplo token that was preemptively invalidated by the user logging out of the web portal. This condition is now checked beforehand and a new token retrieved if necessary.

Adds `AdminGetInfrastructure` to api.go which can be used to perform a Duplo token validating test call. This API is called in a new function `PingDuploCreds` used at the time a Duplo token is read from the cache.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Fix [DUPLO-13529](https://app.clickup.com/t/8655600/DUPLO-13529) 
