### PR TITLE
DUPLO-13646 Fix for obtaining K8s credential with plan ID

### DIFF
--- a/cmd/duplo-jit/main.go
+++ b/cmd/duplo-jit/main.go
@@ -231,7 +231,8 @@ func GetTenantIdAndName(tenantIDorName string, client *duplocloud.Client) (strin
 	} else {
 		// It looks like a UUID, assume it is one and get the tenant name using its ID.
 		var err error
-		tenant, err := client.GetTenantForUser(tenantID)
+		tenantID = tenantIDorName
+		tenant, err := client.GetTenantForUser(tenantIDorName)
 		if tenant == nil || err != nil {
 			internal.Fatal(fmt.Sprintf("%s: tenant missing or not allowed", tenantID), err)
 		} else {


### PR DESCRIPTION
## Change description

Fixes a regression in retrieving K8s credentials when a guid for a plan was provided. Ensure GetTenantIdAndName returns the tenant ID which is the same guid provided.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

- Fix [DUPLO-13595](https://app.clickup.com/t/8655600/DUPLO-13595)
- Fix [DUPLO-13646](https://app.clickup.com/t/8655600/DUPLO-13646)
- Follow-up for test automation [DUPLO-13655](https://app.clickup.com/t/8655600/DUPLO-13655)