### PR TITLE
DUPLO-13650 Elide err when nil from fatal messages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+## 2024-01-24
+
+### Fixed
+- Improved error message format when a tenant is missing or not allowed.
+- Prevented appending a nil error object to fatal error messages.

--- a/cmd/duplo-jit/main.go
+++ b/cmd/duplo-jit/main.go
@@ -224,7 +224,7 @@ func GetTenantIdAndName(tenantIDorName string, client *duplocloud.Client) (strin
 		tenantName = tenantIDorName
 		tenant, err := client.GetTenantByNameForUser(tenantName)
 		if tenant == nil || err != nil {
-			internal.Fatal(fmt.Sprintf("%s: tenant missing or not allowed", tenantName), err)
+			internal.Fatal(fmt.Sprintf("tenant '%s' missing or not allowed", tenantName), err)
 		} else {
 			tenantID = tenant.TenantID
 		}
@@ -234,7 +234,7 @@ func GetTenantIdAndName(tenantIDorName string, client *duplocloud.Client) (strin
 		tenantID = tenantIDorName
 		tenant, err := client.GetTenantForUser(tenantIDorName)
 		if tenant == nil || err != nil {
-			internal.Fatal(fmt.Sprintf("%s: tenant missing or not allowed", tenantID), err)
+			internal.Fatal(fmt.Sprintf("tenant '%s' missing or not allowed", tenantID), err)
 		} else {
 			tenantName = tenant.AccountName
 		}

--- a/internal/util.go
+++ b/internal/util.go
@@ -12,5 +12,8 @@ func DieIf(err error, msg string) {
 }
 
 func Fatal(msg string, err error) {
-	log.Fatalf("%s: %s: %s", os.Args[0], msg, err)
+	if err != nil {
+		log.Fatalf("%s: %s: %s", os.Args[0], msg, err)
+	}
+	log.Fatalf("%s: %s", os.Args[0], msg)
 }


### PR DESCRIPTION
## **User description**
## Change description

Fatal error messages will no longer append the err object to the end when it is nil.

This would appear as " %!s(<nil>)" which looks like something went terribly wrong.

## Type of change
- [x] Bug fix (fixes an issue)
- [ ] New feature (adds functionality)

## Related issues

Fix [DUPLO-13650](https://app.clickup.com/t/8655600/DUPLO-13650)


___

## **Type**
Bug fix


___

## **Description**
- The PR primarily focuses on improving error handling in the application.
- In `cmd/duplo-jit/main.go`, the error message format has been enhanced when a tenant is missing or not allowed.
- In `internal/util.go`, the `Fatal` function has been modified to prevent appending a nil error object to the error message.


___

## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Error handling</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>main.go</strong><dd><code>Enhanced Error Message Format for Missing Tenants</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
cmd/duplo-jit/main.go

- Improved the error message format when a tenant is missing or not <br>  allowed.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duplo-jit/pull/26/files#diff-f7bd766f664e94e84d102e12fec174e24ab97034980dd961e97503c811e33684">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>util.go</strong><dd><code>Prevented Nil Error Object in Fatal Messages</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
internal/util.go

- Modified the `Fatal` function to not append the error object when it <br>  is nil.

    </details>
  </td>
  <td><a href="https://github.com/duplocloud/duplo-jit/pull/26/files#diff-4a98c02a04a96038d6875b39e833779fc588b08dcf9ec098b46b572d5bd3583e">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table><hr>

<details> <summary><strong>✨ Usage guide:</strong></summary><hr> 

**Overview:**
The `describe` tool scans the PR code changes, and generates a description for the PR - title, type, summary, walkthrough and labels. The tool can be triggered [automatically](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) every time a new PR is opened, or can be invoked manually by commenting on a PR.

When commenting, to edit [configurations](https://github.com/Codium-ai/pr-agent/blob/main/pr_agent/settings/configuration.toml#L46) related to the describe tool (`pr_description` section), use the following template:
```
/describe --pr_description.some_config1=... --pr_description.some_config2=...
```
With a [configuration file](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#working-with-github-app), use the following template:
```
[pr_description]
some_config1=...
some_config2=...
```


<table><tr><td><details> <summary><strong> Enabling\disabling automation </strong></summary><hr>

- When you first install the app, the [default mode](https://github.com/Codium-ai/pr-agent/blob/main/Usage.md#github-app-automatic-tools) for the describe tool is:
```
pr_commands = ["/describe --pr_description.add_original_user_description=true" 
                         "--pr_description.keep_original_user_title=true", ...]
```
meaning the `describe` tool will run automatically on every PR, will keep the original title, and will add the original user description above the generated description. 

- Markers are an alternative way to control the generated description, to give maximal control to the user. If you set:
```
pr_commands = ["/describe --pr_description.use_description_markers=true", ...]
```
the tool will replace every marker of the form `pr_agent:marker_name` in the PR description with the relevant content, where `marker_name` is one of the following:
  - `type`: the PR type.
  - `summary`: the PR summary.
  - `walkthrough`: the PR walkthrough.

Note that when markers are enabled, if the original PR description does not contain any markers, the tool will not alter the description at all.
        


</details></td></tr>

<tr><td><details> <summary><strong> Custom labels </strong></summary><hr>

The default labels of the `describe` tool are quite generic: [`Bug fix`, `Tests`, `Enhancement`, `Documentation`, `Other`].

If you specify [custom labels](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md#handle-custom-labels-from-the-repos-labels-page-gem) in the repo's labels page or via configuration file, you can get tailored labels for your use cases.
Examples for custom labels:
- `Main topic:performance` - pr_agent:The main topic of this PR is performance
- `New endpoint` - pr_agent:A new endpoint was added in this PR
- `SQL query` - pr_agent:A new SQL query was added in this PR
- `Dockerfile changes` - pr_agent:The PR contains changes in the Dockerfile
- ...

The list above is eclectic, and aims to give an idea of different possibilities. Define custom labels that are relevant for your repo and use cases.
Note that Labels are not mutually exclusive, so you can add multiple label categories.
Make sure to provide proper title, and a detailed and well-phrased description for each label, so the tool will know when to suggest it.        


</details></td></tr>

<tr><td><details> <summary><strong> Utilizing extra instructions</strong></summary><hr>

The `describe` tool can be configured with extra instructions, to guide the model to a feedback tailored to the needs of your project.

Be specific, clear, and concise in the instructions. With extra instructions, you are the prompter. Notice that the general structure of the description is fixed, and cannot be changed. Extra instructions can change the content or style of each sub-section of the PR description.

Examples for extra instructions:
```
[pr_description] 
extra_instructions="""
- The PR title should be in the format: '<PR type>: <title>'
- The title should be short and concise (up to 10 words)
- ...
"""
```
Use triple quotes to write multi-line instructions. Use bullet points to make the instructions more readable.


</details></td></tr>



<tr><td><details> <summary><strong> More PR-Agent commands</strong></summary><hr> 

> To invoke the PR-Agent, add a comment using one of the following commands:  
> - **/review**: Request a review of your Pull Request.   
> - **/describe**: Update the PR title and description based on the contents of the PR.   
> - **/improve [--extended]**: Suggest code improvements. Extended mode provides a higher quality feedback.   
> - **/ask \<QUESTION\>**: Ask a question about the PR.   
> - **/update_changelog**: Update the changelog based on the PR's contents.   
> - **/add_docs** 💎: Generate docstring for new components introduced in the PR.   
> - **/generate_labels** 💎: Generate labels for the PR based on the PR's contents.   
> - **/analyze** 💎: Automatically analyzes the PR, and presents changes walkthrough for each component.   

>See the [tools guide](https://github.com/Codium-ai/pr-agent/blob/main/docs/TOOLS_GUIDE.md) for more details.
>To list the possible configuration parameters, add a **/config** comment.   
 


</details></td></tr>

</table>

See the [describe usage](https://github.com/Codium-ai/pr-agent/blob/main/docs/DESCRIBE.md) page for a comprehensive guide on using this tool.


</details>
