### PR TITLE
Add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ RUN make
 
 FROM debian:stable-slim
 
+RUN apt-get update && apt-get install -y ca-certificates && rm -rf /var/lib/apt/lists/*
+
 COPY --from=builder /app/duplo-jit /usr/local/bin/duplo-jit
 COPY --from=builder /app/duplo-aws-credential-process /usr/local/bin/duplo-aws-credential-process
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM golang:latest AS builder
+
+COPY . /app
+WORKDIR /app
+
+RUN make
+
+FROM debian:stable-slim
+
+COPY --from=builder /app/duplo-jit /usr/local/bin/duplo-jit
+COPY --from=builder /app/duplo-aws-credential-process /usr/local/bin/duplo-aws-credential-process
+
+ENTRYPOINT [ "duplo-jit" ]


### PR DESCRIPTION
## Change description

> Add a Dockerfile so that duplo-jit can be easily built and run in a container instead of on the host machine. This minimizes the need to trust the security of the duplo-jit codebase in obtaining JIT tokens.
> 
> Example `~/.aws/config`:
```
[profile duplo]
region=us-west-2
credential_process=docker run duplo-jit aws --admin --host https://<environment>.duplocloud.net --token ...
```

## Type of change
- [ ] Bug fix (fixes an issue)
- [X] New feature (adds functionality)

## Checklists

### Development

- [X] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [X] Lint rules pass locally
- [ ] Application changes have been tested thoroughly
- [ ] Automated tests covering modified code pass

### Security

- [ ] Security impact of change has been considered
- [ ] Code follows company security practices and guidelines

### Code review 

- [ ] Pull request has a descriptive title and context useful to a reviewer.
- [ ] "Ready for review" label attached and reviewers assigned
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
