### PR TITLE
DUPLO-26089: use a predetermined localPort

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,8 @@ Usage of duplo-jit:
     	Duplo API base URL
   -interactive
     	Allow getting Duplo credentials via an interactive browser session
+  -port
+    	Allow choosing a port for the interactive browser session. Default is random
   -no-cache
     	Disable caching (not recommended)
   -tenant string
@@ -73,6 +75,8 @@ Usage of duplo-jit:
     	Duplo API base URL
   -interactive
     	Allow getting Duplo credentials via an interactive browser session
+  -port
+    	Allow choosing a port for the interactive browser session. Default is random
   -no-cache
     	Disable caching (not recommended)
   -token string

--- a/cmd/duplo-aws-credential-process/main.go
+++ b/cmd/duplo-aws-credential-process/main.go
@@ -12,7 +12,7 @@ import (
 	"github.com/duplocloud/duplo-jit/internal"
 )
 
-func mustDuploClient(host, token string, interactive, admin bool) *duplocloud.Client {
+func mustDuploClient(host, token string, interactive, admin bool, port int) *duplocloud.Client {
 	otp := ""
 
 	// Possibly get a token from an interactive process.
@@ -21,7 +21,7 @@ func mustDuploClient(host, token string, interactive, admin bool) *duplocloud.Cl
 			log.Fatalf("%s: --token not specified and --interactive mode is disabled", os.Args[0])
 		}
 
-		tokenResult := internal.MustTokenInteractive(host, admin, "duplo-aws-credential-process")
+		tokenResult := internal.MustTokenInteractive(host, admin, "duplo-aws-credential-process", port)
 		token = tokenResult.Token
 		otp = tokenResult.OTP
 	}
@@ -50,6 +50,7 @@ func main() {
 	noCache := flag.Bool("no-cache", false, "Disable caching (not recommended)")
 	interactive := flag.Bool("interactive", false, "Allow getting Duplo credentials via an interactive browser session")
 	showVersion := flag.Bool("version", false, "Output version information and exit")
+	port := flag.Int("port", 0, "Port to use for the local web server")
 	flag.Parse()
 
 	// Output version information
@@ -92,7 +93,7 @@ func main() {
 
 		// Otherwise, get the credentials from Duplo.
 		if creds == nil {
-			client := mustDuploClient(*host, *token, *interactive, true)
+			client := mustDuploClient(*host, *token, *interactive, true, *port)
 			result, err := client.AdminGetJitAwsCredentials()
 			internal.DieIf(err, "failed to get credentials")
 			creds = internal.ConvertAwsCreds(result)
@@ -108,7 +109,7 @@ func main() {
 
 		// Otherwise, get the credentials from Duplo.
 		if creds == nil {
-			client := mustDuploClient(*host, *token, *interactive, true)
+			client := mustDuploClient(*host, *token, *interactive, true, *port)
 			result, err := client.AdminAwsGetJitAccess("duplo-ops")
 			internal.DieIf(err, "failed to get credentials")
 			creds = internal.ConvertAwsCreds(result)
@@ -129,7 +130,7 @@ func main() {
 
 		// Otherwise, get the credentials from Duplo.
 		if creds == nil {
-			client := mustDuploClient(*host, *token, *interactive, false)
+			client := mustDuploClient(*host, *token, *interactive, false, *port)
 
 			// If it doesn't look like a UUID, get the tenant ID from the name.
 			if len(*tenantID) < 32 {

--- a/cmd/duplo-jit/main.go
+++ b/cmd/duplo-jit/main.go
@@ -31,6 +31,7 @@ func main() {
 	debug := flag.Bool("debug", false, "Turn on verbose (debugging) output")
 	noCache := flag.Bool("no-cache", false, "Disable caching (not recommended)")
 	interactive := flag.Bool("interactive", false, "Allow getting Duplo credentials via an interactive browser session")
+	port := flag.Int("port", 0, "Port to use for the local web server")
 	showVersion := flag.Bool("version", false, "Output version information and exit")
 	admin = new(bool)
 	duploOps = new(bool)
@@ -105,7 +106,7 @@ func main() {
 
 			// Otherwise, get the credentials from Duplo.
 			if creds == nil {
-				client, _ := internal.MustDuploClient(*host, *token, *interactive, true)
+				client, _ := internal.MustDuploClient(*host, *token, *interactive, true, *port)
 				result, err := client.AdminGetJitAwsCredentials()
 				internal.DieIf(err, "failed to get credentials")
 				creds = internal.ConvertAwsCreds(result)
@@ -121,7 +122,7 @@ func main() {
 
 			// Otherwise, get the credentials from Duplo.
 			if creds == nil {
-				client, _ := internal.MustDuploClient(*host, *token, *interactive, true)
+				client, _ := internal.MustDuploClient(*host, *token, *interactive, true, *port)
 				result, err := client.AdminAwsGetJitAccess("duplo-ops")
 				internal.DieIf(err, "failed to get credentials")
 				creds = internal.ConvertAwsCreds(result)
@@ -136,7 +137,7 @@ func main() {
 
 			// Identify the tenant name to use for the cache key.
 			var tenantName string
-			client, _ := internal.MustDuploClient(*host, *token, *interactive, false)
+			client, _ := internal.MustDuploClient(*host, *token, *interactive, false, *port)
 			*tenantID, tenantName = GetTenantIdAndName(*tenantID, client)
 
 			// Build the cache key.
@@ -158,7 +159,7 @@ func main() {
 		internal.OutputAwsCreds(creds, cacheKey)
 
 	case "duplo":
-		_, creds := internal.MustDuploClient(*host, *token, *interactive, true)
+		_, creds := internal.MustDuploClient(*host, *token, *interactive, true, *port)
 		internal.OutputDuploCreds(creds)
 
 	case "k8s":
@@ -174,7 +175,7 @@ func main() {
 
 			// Otherwise, get the credentials from Duplo.
 			if creds == nil {
-				client, _ := internal.MustDuploClient(*host, *token, *interactive, true)
+				client, _ := internal.MustDuploClient(*host, *token, *interactive, true, *port)
 				result, err := client.AdminGetK8sJitAccess(*planID)
 				internal.DieIf(err, "failed to get credentials")
 				creds = internal.ConvertK8sCreds(result)
@@ -189,7 +190,7 @@ func main() {
 
 			// Identify the tenant name to use for the cache key.
 			var tenantName string
-			client, _ := internal.MustDuploClient(*host, *token, *interactive, false)
+			client, _ := internal.MustDuploClient(*host, *token, *interactive, false, *port)
 			*tenantID, tenantName = GetTenantIdAndName(*tenantID, client)
 
 			// Build the cache key.

--- a/internal/duplo.go
+++ b/internal/duplo.go
@@ -38,7 +38,7 @@ func duploClientAndOtpFlag(host, token, otp string, admin bool) (*duplocloud.Cli
 }
 
 // MustDuploClient retrieves a duplo client (and credentials) or panics.
-func MustDuploClient(host, token string, interactive, admin bool) (client *duplocloud.Client, creds *DuploCredsOutput) {
+func MustDuploClient(host, token string, interactive, admin bool, port int) (client *duplocloud.Client, creds *DuploCredsOutput) {
 	needsOtp := false
 	cacheKey := strings.TrimPrefix(host, "https://")
 
@@ -91,7 +91,7 @@ func MustDuploClient(host, token string, interactive, admin bool) (client *duplo
 		}
 
 		// Get the token, or fail.
-		tokenResult := MustTokenInteractive(host, admin, "duplo-jit")
+		tokenResult := MustTokenInteractive(host, admin, "duplo-jit", port)
 		if tokenResult.Token == "" {
 			log.Fatalf("%s: authentication failure: failed to get token interactively", os.Args[0])
 		}

--- a/internal/interactive.go
+++ b/internal/interactive.go
@@ -63,7 +63,7 @@ func handlerTokenViaPost(baseUrl string, res http.ResponseWriter, req *http.Requ
 func TokenViaPost(baseUrl string, admin bool, cmd string, port int, timeout time.Duration) TokenResult {
 
 	// Create the listener on a random port.
-	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%s", port))
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
 	if err != nil {
 		return TokenResult{err: err}
 	}

--- a/internal/interactive.go
+++ b/internal/interactive.go
@@ -60,10 +60,10 @@ func handlerTokenViaPost(baseUrl string, res http.ResponseWriter, req *http.Requ
 	return
 }
 
-func TokenViaPost(baseUrl string, admin bool, cmd string, timeout time.Duration) TokenResult {
+func TokenViaPost(baseUrl string, admin bool, cmd string, port int, timeout time.Duration) TokenResult {
 
 	// Create the listener on a random port.
-	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	listener, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%s", port))
 	if err != nil {
 		return TokenResult{err: err}
 	}
@@ -127,8 +127,8 @@ func TokenViaPost(baseUrl string, admin bool, cmd string, timeout time.Duration)
 	}
 }
 
-func MustTokenInteractive(host string, admin bool, cmd string) (tokenResult TokenResult) {
-	tokenResult = TokenViaPost(host, admin, cmd, 180*time.Second)
+func MustTokenInteractive(host string, admin bool, cmd string, port int) (tokenResult TokenResult) {
+	tokenResult = TokenViaPost(host, admin, cmd, port, 180*time.Second)
 	DieIf(tokenResult.err, "failed to get token from interactive browser session")
 	return
 }


### PR DESCRIPTION
## Overview

Proposed by Ofir @ Seven AI

`duplo-jit` to have it use a predetermined localPort, which could then be exposed from devcontainer



----

Slack:

question for the duplo folks about duplo-jit + aws + admin access
specifically, this part of the ~/.aws/config file:
```
[profile playground]
region = us-east-2
credential_process = duplo-jit aws --admin --host https://duplo.cloud.sevenai.com/ --interactive
```
some of our team is working within a visual studio devcontainer , so when duplo-jit sends us out to the browser to click "Authorize" , the authorize button won't work because the localPort isn't exposed from our devcontainer
example url: https://duplo.cloud.sevenai.com/app/user/verify-token?localAppName=duplo-jit&localPort=45461&isAdmin=true
what is the recommended solution ?  I believe Ofir was hacking around on duplo-jit to have it use a predetermined localPort, which could then be exposed from devcontainer, in case that helps
