### PR TITLE
DUPLO-26219 Fix lint GitHub Action

### DIFF
--- a/.github/workflows/dev-check.yml
+++ b/.github/workflows/dev-check.yml
@@ -18,10 +18,10 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.23
       - 
         name: Run linting
-        uses: golangci/golangci-lint-action@v3
+        uses: golangci/golangci-lint-action@v6
         with:
           only-new-issues: true  # Only show new issues for pull requests.
   format:
@@ -34,7 +34,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.23
       - 
         name: Run formatting
         run: gofmt -s -w duplocloud cmd/duplo-aws-credential-process

--- a/.github/workflows/dev-test.yml
+++ b/.github/workflows/dev-test.yml
@@ -18,7 +18,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.23
       -
         name: Run tests
         run: make test

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -17,7 +17,7 @@ jobs:
         name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21
+          go-version: 1.23
       -
         name: Run tests
         run: make test

--- a/cmd/duplo-jit/main.go
+++ b/cmd/duplo-jit/main.go
@@ -138,7 +138,7 @@ func main() {
 			// Identify the tenant name to use for the cache key.
 			var tenantName string
 			client, _ := internal.MustDuploClient(*host, *token, *interactive, false, *port)
-			*tenantID, tenantName = GetTenantIdAndName(*tenantID, client)
+			*tenantID, tenantName = getTenantIDAndName(*tenantID, client)
 
 			// Build the cache key.
 			cacheKey = strings.Join([]string{strings.TrimPrefix(*host, "https://"), "tenant", tenantName}, ",")
@@ -191,7 +191,7 @@ func main() {
 			// Identify the tenant name to use for the cache key.
 			var tenantName string
 			client, _ := internal.MustDuploClient(*host, *token, *interactive, false, *port)
-			*tenantID, tenantName = GetTenantIdAndName(*tenantID, client)
+			*tenantID, tenantName = getTenantIDAndName(*tenantID, client)
 
 			// Build the cache key.
 			cacheKey = strings.Join([]string{strings.TrimPrefix(*host, "https://"), "tenant", tenantName}, ",")
@@ -215,7 +215,7 @@ func main() {
 	}
 }
 
-func GetTenantIdAndName(tenantIDorName string, client *duplocloud.Client) (string, string) {
+func getTenantIDAndName(tenantIDorName string, client *duplocloud.Client) (string, string) {
 	var tenantID string
 	var tenantName string
 

--- a/duplocloud/api.go
+++ b/duplocloud/api.go
@@ -100,12 +100,12 @@ func (c *Client) AdminGetK8sJitAccess(plan string) (*DuploPlanK8ClusterConfig, C
 	return &creds, nil
 }
 
-// AdminGetJITAwsCredentials retrieves just-in-time admin AWS credentials via the Duplo API.
+// AdminGetJitAwsCredentials retrieves just-in-time admin AWS credentials via the Duplo API.
 func (c *Client) AdminGetJitAwsCredentials() (*AwsJitCredentials, ClientError) {
 	return c.AdminAwsGetJitAccess("admin")
 }
 
-// TenantGetJITAwsCredentials retrieves just-in-time AWS credentials for a tenant via the Duplo API.
+// TenantGetJitAwsCredentials retrieves just-in-time AWS credentials for a tenant via the Duplo API.
 func (c *Client) TenantGetJitAwsCredentials(tenantID string) (*AwsJitCredentials, ClientError) {
 	creds := AwsJitCredentials{}
 	err := c.getAPI(
@@ -143,11 +143,12 @@ func (c *Client) ListTenantsForUser() (*[]UserTenant, ClientError) {
 	return &list, nil
 }
 
-func (c *Client) GetTenantFeatures(tenantId string) (*DuploTenantFeatures, ClientError) {
+// GetTenantFeatures retrieves a tenant's current configuration via the Duplo API.
+func (c *Client) GetTenantFeatures(tenantID string) (*DuploTenantFeatures, ClientError) {
 	features := DuploTenantFeatures{}
 	err := c.getAPI(
-		fmt.Sprintf("GetTenantFeatures(%s)", tenantId),
-		fmt.Sprintf("v3/features/tenant/%s", tenantId),
+		fmt.Sprintf("GetTenantFeatures(%s)", tenantID),
+		fmt.Sprintf("v3/features/tenant/%s", tenantID),
 		&features,
 	)
 	if err != nil {

--- a/duplocloud/client.go
+++ b/duplocloud/client.go
@@ -9,7 +9,7 @@ import (
 	"time"
 )
 
-// Represents a connection to the Duplo API
+// Client represents a connection to the Duplo API
 type Client struct {
 	HTTPClient *http.Client
 	HostURL    string
@@ -66,7 +66,7 @@ func (e clientError) Response() map[string]interface{} {
 	return e.response
 }
 
-// Represents an error from an API call.
+// ClientError represents an error from an API call.
 type ClientError interface {
 	Error() string
 	Status() int

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/duplocloud/duplo-jit
 
-go 1.21
+go 1.23
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.23.5

--- a/internal/cache.go
+++ b/internal/cache.go
@@ -98,7 +98,7 @@ func CacheGetAwsConfigOutput(cacheKey string) (creds *AwsConfigOutput) {
 
 		// Check credentials for expiry.
 		if creds != nil {
-			five_minutes_from_now := time.Now().UTC().Add(5 * time.Minute)
+			fiveMinutesFromNow := time.Now().UTC().Add(5 * time.Minute)
 			expiration, err := time.Parse(time.RFC3339, creds.Expiration)
 
 			// Invalid expiration?
@@ -107,7 +107,7 @@ func CacheGetAwsConfigOutput(cacheKey string) (creds *AwsConfigOutput) {
 				creds = nil
 
 				// Expires in five minutes or less?
-			} else if five_minutes_from_now.After(expiration) {
+			} else if fiveMinutesFromNow.After(expiration) {
 				creds = nil
 			}
 		}
@@ -189,9 +189,9 @@ func CacheGetK8sConfigOutput(cacheKey string, tenantName string) (creds *clienta
 		// Check credentials for expiry.
 		if creds != nil {
 			// Expires in five minutes or less?
-			five_minutes_from_now := time.Now().UTC().Add(5 * time.Minute)
+			fiveMinutesFromNow := time.Now().UTC().Add(5 * time.Minute)
 			expiration := creds.Status.ExpirationTimestamp.Time
-			if five_minutes_from_now.After(expiration) {
+			if fiveMinutesFromNow.After(expiration) {
 				creds = nil
 			}
 		}


### PR DESCRIPTION
## Change description

The version of the golangci-lint-action no longer passes. This upgrades it, as well as some others to a new version.

## Type of change
Build fix

## Related issues

> Fix [DUPLO-26219](https://app.clickup.com/t/8655600/DUPLO-26219) 

## Checklists

### Development

- [x] Pull requests may not be submitted to the *master* branch (use *develop* instead) - or they will be closed.
- [x] Lint rules pass locally

### Security

- [x] Security impact of change has been considered
- [x] Code follows company security practices and guidelines

### Code review 

- [x] Pull request has a descriptive title and context useful to a reviewer.
- [ ] Changes have been reviewed by at least one other contributor
- [ ] Pull request linked to task tracker where applicable
